### PR TITLE
fix running non-social dannce predict

### DIFF
--- a/dannce/cli.py
+++ b/dannce/cli.py
@@ -954,3 +954,7 @@ def main():
         elif args.mode == "com":
             com_predict(params)
         return
+
+if __name__ == "__main__":
+    main()
+    

--- a/dannce/engine/run/run_utils.py
+++ b/dannce/engine/run/run_utils.py
@@ -1103,9 +1103,13 @@ def make_dataset_inference(params, valid_params):
     #     "occlusion": params.get("downscale_occluded_view", False)}
     #     if params["social_training"]
     #     else {}
-    spec_params = {
-        "n_instances": params["n_instances"]
-    }
+    if params['social_training']:
+        spec_params = {
+            "n_instances": params["n_instances"]
+        }
+    else:
+        spec_params = {}
+        
     predict_generator = genfunc(*predict_params, **valid_params, **spec_params)
 
     predict_generator_sil = None


### PR DESCRIPTION
Fix issue when running `dannce predict ...` 

Issue is:
- DataGenerator_3dconv_social takes an param `n_instances`
- DataGenerator_3dconv [non-social] does not take param `n_instances` and crashes when it is supplied by deafult

Fix is: 
- only provide `spec_params = { n_instances: ... }` if you're running social training, otherwise provide an empty object: `spec_params = {}`