### PR TITLE
support specifying  --max-num-samples='max'

### DIFF
--- a/dannce/cli.py
+++ b/dannce/cli.py
@@ -23,6 +23,24 @@ from dannce import (
     _param_defaults_com,
 )
 
+from typing import List
+
+SINGLE_QUOTE="'"
+
+def int_or_literal(literals: List[str], argname="arg"):
+    """Helper function for argparse which will take either a int parsed as a string or a string which matches one of a set of literals"""
+
+    def inner(arg):
+        try:
+            return int(arg)
+        except ValueError:
+            pass
+        if arg in literals:
+            return arg
+        raise argparse.ArgumentTypeError(f"{argname} must be an int or {','.join(map(lambda x : SINGLE_QUOTE + x +SINGLE_QUOTE, literals))}")
+
+    return inner
+
 
 def load_params(param_path: Text) -> Dict:
     """Load a params file
@@ -267,7 +285,7 @@ def add_shared_predict_args(
     parser.add_argument(
         "--max-num-samples",
         dest="max_num_samples",
-        type=int,
+        type=int_or_literal(['max'], '--max-num-samples'),
         help="Maximum number of samples to predict during COM or DANNCE prediction.",
     )
     parser.add_argument(

--- a/dannce/config.py
+++ b/dannce/config.py
@@ -209,13 +209,11 @@ def infer_params(params: dict, dannce_net: bool, prediction: bool) -> dict:
     ###########################################
     if params["max_num_samples"] == "max" or params["max_num_samples"] is None:
         print_and_set(params, "maxbatch", "max")
-    elif params["max_num_samples"].isdigit():
+    else:
         print_and_set(params, "max_num_samples", int(params["max_num_samples"]))
         maxbatch = int(np.ceil(params["max_num_samples"] / params["batch_size"]))
         print_and_set(params, "maxbatch", maxbatch)
-    else:
-        raise TypeError("max_num_samples must be an int or 'max'")
-
+    
     # start_batch
     ###########################################
     if params["start_sample"] is None:


### PR DESCRIPTION
support specifying  --max-num-samples='max' in argument parser

minor fix in config when max-num-samples is an int,